### PR TITLE
Suid Defined for Nmap Capability Defination Didn't Work

### DIFF
--- a/tools/nmap.yaml
+++ b/tools/nmap.yaml
@@ -1,6 +1,6 @@
 package:
   name: nmap
-  version: 7.93
+  version: 7.94
   epoch: 0
   description: "network discovery and security auditing tool"
   copyright:
@@ -15,13 +15,19 @@ environment:
     packages:
       - wolfi-base
       - build-base
+      - openssl-dev
 
 pipeline:
   - uses: fetch 
     with: 
       uri: https://nmap.org/dist/nmap-${{package.version}}.tar.bz2
-      expected-sha256: 55bcfe4793e25acc96ba4274d8c4228db550b8e8efd72004b38ec55a2dd16651  
+      expected-sha256: d71be189eec43d7e099bac8571509d316c4577ca79491832ac3e1217bc8f92cc 
   - uses: autoconf/configure
   - uses: autoconf/make
   - uses: autoconf/make-install
-
+  - uses: strip
+  - runs: |
+      # nmap require cap_net_raw,cap_net_admin,cap_net_bind_service+eip while working nonroot
+      # capabilities can define but they don't pass to container.
+      # suid defined
+      chmod 4755 ${{targets.destdir}}/usr/bin/nmap


### PR DESCRIPTION
- version updated
- nmap requires cap_net_raw,cap_net_admin,cap_net_bind_service+eip, but they can't be defined properly via apko+melange
- suid permission defined for running nmap with --privileged